### PR TITLE
Darker background for inactive-pane.

### DIFF
--- a/src/gtk-3.20/scss/apps/_nemo.scss
+++ b/src/gtk-3.20/scss/apps/_nemo.scss
@@ -17,6 +17,7 @@
     }
 
     .nemo-window {
+        .nemo-inactive-pane .view { background-color: $dark_bg_color; }
         toolbar {
             border-width: 0 0 1px;
             border-style: solid;


### PR DESCRIPTION
Allows for a darker background in the in-active pane in dual pane view in Nemo