### PR TITLE
Fix prelit color of clearlooks-base-radiocheck

### DIFF
--- a/src/gtk-2.0/gtkrc
+++ b/src/gtk-2.0/gtkrc
@@ -335,7 +335,7 @@ style "clearlooks-radiocheck" = "murrine-default" {
 }
 
 style "clearlooks-base-radiocheck" = "clearlooks-radiocheck" {
-	bg[PRELIGHT] = @base_color
+	bg[PRELIGHT] = @bg_color
 }
 
 style "murrine-entry" = "murrine-wider" {

--- a/src/gtk-2.0/gtkrc.hidpi
+++ b/src/gtk-2.0/gtkrc.hidpi
@@ -331,7 +331,7 @@ style "clearlooks-radiocheck" = "murrine-default" {
 }
 
 style "clearlooks-base-radiocheck" = "clearlooks-radiocheck" {
-	bg[PRELIGHT] = @base_color
+	bg[PRELIGHT] = @bg_color
 }
 
 style "murrine-entry" = "murrine-wider" {


### PR DESCRIPTION
I noticed the following glitch in the gtk2 theme: in dialog windows, when the mouse hovers on a checkbox or its text, the background color of both changes from BG_COLOR to BASE_COLOR:
![radio-screen1](https://user-images.githubusercontent.com/20945263/35471706-1a4d1a8a-0361-11e8-8899-cfbb27887698.png)
This PR sets the color to BG_COLOR instead:
![radio-screen2](https://user-images.githubusercontent.com/20945263/35471707-1a6c86d6-0361-11e8-8d92-1e880a23e3ce.png)
Is this the right place to submit this? Or should I send it to the original numix theme, and then you merge it later? 