### PR TITLE
Add unfocused window border on server-side rendered decorations

### DIFF
--- a/src/gtk-3.20/scss/widgets/_window.scss
+++ b/src/gtk-3.20/scss/widgets/_window.scss
@@ -37,7 +37,13 @@
         // see bug #722563
         // server-side decorations as used by mutter
         // Fixed gtk-3.18 Unity bug (https://github.com/numixproject/numix-gtk-theme/issues/270)
-        .ssd & { box-shadow: 0 0 0 1px $wm_border_focused; } //just doing borders, wm draws actual shadows
+        .ssd & {
+            box-shadow: 0 0 0 1px $wm_border_focused;
+
+            &:backdrop {
+                box-shadow: 0 0 0 1px $wm_border_unfocused;
+            }
+        } //just doing borders, wm draws actual shadows
 
         .solid-csd & {
             border-radius: 0;


### PR DESCRIPTION
Fixed https://github.com/actionless/oomox/issues/123