### PR TITLE
GTK3.18 & GTK3.20 - Fix $error-color typo to $error_color

### DIFF
--- a/src/gtk-3.0/scss/widgets/_actionbar.scss
+++ b/src/gtk-3.0/scss/widgets/_actionbar.scss
@@ -59,7 +59,7 @@
 @include exports("actionbuttons") {
     $types: (
         suggested: $success_color,
-        destructive: $error-color
+        destructive: $error_color
     );
 
     @each $type, $color in $types {

--- a/src/gtk-3.20/scss/widgets/_actionbar.scss
+++ b/src/gtk-3.20/scss/widgets/_actionbar.scss
@@ -39,7 +39,7 @@
 @include exports("actionbuttons") {
     $types: (
         suggested: $success_color,
-        destructive: $error-color
+        destructive: $error_color
     );
 
     @each $type, $color in $types {


### PR DESCRIPTION
I'm pretty sure this is an uncaught typo.