### PR TITLE
GTK3 - fix active/checked button bg color to bring in line with GTK3.…

### DIFF
--- a/src/gtk-3.0/scss/widgets/_button.scss
+++ b/src/gtk-3.0/scss/widgets/_button.scss
@@ -149,7 +149,7 @@
         }
 
         &:active, &:checked {
-            @include linear-gradient(shade($button_bg, .7), to top);
+            @include linear-gradient(shade($selected_bg_color, .9), to top);
 
             color: $selected_fg_color;
             box-shadow: inset 1px 0 alpha($dark_shadow, .06),
@@ -158,7 +158,7 @@
                         inset 0 -1px alpha($dark_shadow, .05);
 
             &:focus, &:hover {
-                @include linear-gradient(shade($button_bg, .65), to top);
+                @include linear-gradient(shade($selected_bg_color, .8), to top);
 
                 color: $selected_fg_color;
             }


### PR DESCRIPTION
…20 and fix visibility issues in some themes.

Hi - the equivalent buttons are already colored in this way in the GTK3.20 theme.

New and previous

![screenshot from 2018-03-17 04-49-55](https://user-images.githubusercontent.com/29017677/37551776-5fdae0dc-299f-11e8-81a5-5f2f74588fae.png)
![screenshot from 2018-03-17 04-45-20](https://user-images.githubusercontent.com/29017677/37551777-5ff47358-299f-11e8-8b03-5b83918e428e.png)

![screenshot from 2018-03-17 04-56-17](https://user-images.githubusercontent.com/29017677/37551786-93d15984-299f-11e8-9a06-edabf9087ba1.png)
![screenshot from 2018-03-17 04-47-23](https://user-images.githubusercontent.com/29017677/37551787-93eadb3e-299f-11e8-96a6-d4dc167827c7.png)

![screenshot from 2018-03-17 04-55-59](https://user-images.githubusercontent.com/29017677/37551789-a34fc2d8-299f-11e8-9c2b-84f34237874d.png)
![screenshot from 2018-03-17 04-47-00](https://user-images.githubusercontent.com/29017677/37551790-a3651b74-299f-11e8-8d91-8064cde4d57c.png)


