### PR TITLE
Cinnamon Theme - distinguish between interior and exterior borders

### DIFF
--- a/src/cinnamon/scss/_extends.scss
+++ b/src/cinnamon/scss/_extends.scss
@@ -8,7 +8,7 @@
 }
 
 // button to top
-%button-bg-grad-to-top{
+%button-bg-grad-to-top {
     background-gradient-direction: vertical;
     background-gradient-start: $light_button_bg_grad;
     background-gradient-end: $dark_button_bg_grad;
@@ -77,12 +77,11 @@
     background-gradient-end: $dark_tooltip_bg_grad;
 }
 
-
 // used in selectors
 // .osd-window, .info-osd, .info-osd
 %osd-shared {
     @extend %bg-grad-to-bottom;
-    border: 1px solid $borders_color;
+    border: 1px solid $exterior_border;
     border-radius: $roundness;
     color: $dark_fg_color;
 }
@@ -95,9 +94,9 @@
     color: $dark_fg_color;
     -slider-height: 0.7em;
     -slider-background-color: $scrollbar_bg_color;
-    -slider-border-color: $borders_color;
+    -slider-border-color: $interior_border;
     -slider-active-background-color: $scrollbar_slider_hover_color;
-    -slider-active-border-color: $selected_borders_color;
+    -slider-active-border-color: $selected_border;
     -slider-border-width: 1px;
     -slider-border-radius: 0.3em;
     -slider-handle-radius: 0.7em;
@@ -120,8 +119,7 @@
     padding: 2px;
     border-radius: $roundness;
     color: $tooltip_fg_color;
-    font-weight: bold;
-    border: 1px solid $borders_color;
+    border: 1px solid $interior_border;
     selection-background-color: $selected_bg_color;
     selected-color: $selected_fg_color;
     caret-color: $primary_caret_color;
@@ -136,7 +134,7 @@
 %desklet-shared {
     color: $dark_fg_color;
     padding: 10px;
-    border: 1px solid $borders_color;
+    border: 1px solid $exterior_border;
     @extend %bg-grad-to-right;
 }
 
@@ -164,7 +162,7 @@
 // .notification-button:hover, .notification-icon-button:hover, .modal-dialog-button:hover, .sound-player-overlay StButton:hover, .keyboard-key:hover
 %shared-button-hover {
     @extend %hover-button-bg-grad-to-top;
-    border: 1px solid $selected_borders_color;
+    border: 1px solid $selected_border;
 }
 
 // used in selectors
@@ -185,7 +183,7 @@
 // .menu, .popup-menu, .popup-combo-menu
 %shared-menu {
     padding: 10px;
-    border: 1px solid $borders_color;
+    border: 1px solid $exterior_border;
     border-radius: $roundness;
     @extend %bg-grad-to-right;
     color: $dark_fg_color;
@@ -222,7 +220,7 @@
     padding: 5px;
     margin: 0.5em 0;
     border-radius: $roundness;
-    border: 1px solid $borders_color;
+    border: 1px solid $interior_border;
     @extend %bg-grad-to-bottom;
 }
 
@@ -289,12 +287,12 @@
 // .tile-preview, .tile-hud
 %tile-shared {
     background-color: $dark_bg_color_trans;
-    border: 2px solid $borders_color;
+    border: 2px solid $exterior_border;
 }
 
 // used in selectors
 // .tile-preview.snap, .tile-hud.snap
 %tile-shared-snap {
     background-color: $dark_bg_color_trans;
-    border: 2px solid $selected_borders_color;
+    border: 2px solid $selected_border;
 }

--- a/src/cinnamon/scss/_global.scss
+++ b/src/cinnamon/scss/_global.scss
@@ -39,9 +39,11 @@ $dark_hover_button_bg_grad: if($darken_amount < 1, darken($hover_button_bg, (1 -
 $light_tooltip_bg_grad: if($lighten_amount > 1, lighten($tooltip_bg_color, ($lighten_amount - 1) * lightness($tooltip_bg_color)), $tooltip_bg_color);
 $dark_tooltip_bg_grad: if($darken_amount < 1, darken($tooltip_bg_color, (1 - $darken_amount) * lightness($tooltip_bg_color)), $tooltip_bg_color);
 
-// borders used throughout theme Buttons also use selected_borders_color
-$selected_borders_color: mix($dark_bg_color, $selected_bg_color, if(lightness($dark_bg_color) < 50%, 18%, 10%));
-$borders_color: mix($dark_bg_color, $dark_fg_color, if(lightness($dark_bg_color) < 50%, 18%, 10%));
+// borders used throughout theme buttons also use selected_borders_color
+$selected_border: mix($dark_bg_color, $selected_bg_color, if(lightness($dark_bg_color) < 50%, 18%, 10%));
+$border_strength: if(lightness($dark_fg_color) > 50, .1, .2);
+$interior_border: fade-out($dark_fg_color, 0.88 - $border_strength);
+$exterior_border: mix($dark_bg_color, $dark_fg_color, (30 + ($border_strength * 100)));
 
 // decoration for buttons
 $button_border_strength: if(lightness($button_fg_color) > 50, .1, .2);

--- a/src/cinnamon/scss/sections/_accessibility.scss
+++ b/src/cinnamon/scss/sections/_accessibility.scss
@@ -11,7 +11,7 @@
         border-color: $selected_fg_color;
     }
     &:checked {
-        border-color: $selected_borders_color;
+        border-color: $selected_border;
     }
     &:hover {
         @extend %shared-button-hover;
@@ -40,7 +40,7 @@
 }
 // desktop zoom feature
 .magnifier-zoom-region {
-    border: 3px solid $borders_color;
+    border: 3px solid $exterior_border;
     &.full-screen {
         border-width: 0;
     }

--- a/src/cinnamon/scss/sections/_alt-tab.scss
+++ b/src/cinnamon/scss/sections/_alt-tab.scss
@@ -6,7 +6,7 @@
 .switcher-list {
     @extend %bg-grad-to-bottom;
     border-radius: $roundness;
-    border: 1px solid $borders_color;
+    border: 1px solid $exterior_border;
     padding: 20px;
     color: $dark_fg_color;
     .item-box {
@@ -14,7 +14,7 @@
         border-radius: $roundness;
         &:outlined {
             padding: 6px;
-            border: 1px solid $borders_color;
+            border: 1px solid $interior_border;
         }
         &:selected {
             @extend %selected-bg-grad-to-bottom;

--- a/src/cinnamon/scss/sections/_dialogs.scss
+++ b/src/cinnamon/scss/sections/_dialogs.scss
@@ -1,6 +1,6 @@
 // on screen messages and input boxes
 .modal-dialog {
-    border: 1px solid $borders_color;
+    border: 1px solid $exterior_border;
     border-radius: $roundness;
     @extend %bg-grad-to-right;
     color: $dark_fg_color;
@@ -48,6 +48,9 @@
 }
 .run-dialog-entry {
         @extend %dialog-entry;
+        &:focus  {
+            border: 1px solid $selected_border;
+        }
 }
 .run-dialog {
     border-radius: $roundness;
@@ -171,7 +174,7 @@
     padding-right: 20px;
 }
 .about-scrollBox {
-    border: 1px solid $borders_color;
+    border: 1px solid $exterior_border;
     border-radius: $roundness;
 }
 .about-scrollBox-innerBox {
@@ -189,7 +192,7 @@
     @extend %bg-grad-to-bottom;
     spacing: 4px;
     padding: 10px;
-    border: 1px solid $borders_color;
+    border: 1px solid $exterior_border;
     border-radius: $roundness;
     color: $dark_fg_color;
 }

--- a/src/cinnamon/scss/sections/_menu.scss
+++ b/src/cinnamon/scss/sections/_menu.scss
@@ -3,7 +3,7 @@
     -arrow-border-radius: $roundness;
     -arrow-background-color: $dark_bg_color;
     -arrow-border-width: 1px;
-    -arrow-border-color: $borders_color;
+    -arrow-border-color: $exterior_border;
     -arrow-base: 24px;
     -arrow-rise: 11px;
 }
@@ -26,7 +26,7 @@
 // applet submenus
 .popup-sub-menu {
     @extend %bg-grad-to-bottom;
-    border: 1px solid $borders_color;
+    border: 1px solid $interior_border;
     border-radius: $roundness;
     padding: 5px;
     margin: 0.5em 0;
@@ -131,7 +131,7 @@
 // it includes some themeing to ensure constency in right click context menu behavior in third party menu applets.
 .menu-favorites-box {
     padding: 10px;
-    border: 1px solid $borders_color;
+    border: 1px solid $interior_border;
     border-radius: $roundness;
     @extend %bg-grad-to-right;
     transition-duration: 150;
@@ -149,7 +149,7 @@
 }
 .menu-places-box {
     padding: 10px;
-    border: 1px solid $borders_color;
+    border: 1px solid $interior_border;
     border-radius: $roundness;
     @extend %bg-grad-to-right;
 }
@@ -162,7 +162,7 @@
 .menu-applications-inner-box {
     padding: 10px;
     border-radius: $roundness;
-    border: 1px solid $borders_color;
+    border: 1px solid $interior_border;
     @extend %bg-grad-to-right;
     StScrollView {
         @extend %menu-context-shared;
@@ -170,7 +170,7 @@
 }
 .menu-applications-outer-box {
     padding: 10px;
-    border: 1px solid $borders_color;
+    border: 1px solid $interior_border;
     border-radius: $roundness;
     @extend %bg-grad-to-right;
 }
@@ -252,7 +252,7 @@
     @extend %dialog-entry;
     margin: 0.5em 0;
     &:focus {
-        border: 1px solid $selected_borders_color;
+        border: 1px solid $selected_border;
     }
     &:hover {
     }

--- a/src/cinnamon/scss/sections/_notifications.scss
+++ b/src/cinnamon/scss/sections/_notifications.scss
@@ -1,7 +1,7 @@
 // notification system
 #notification {
     border-radius: $roundness;
-    border: 1px solid $borders_color;
+    border: 1px solid $exterior_border;
     @extend %bg-grad-to-right;
     padding: 8px;
     spacing-rows: 5px;
@@ -16,7 +16,7 @@
     StEntry {
         @extend %dialog-entry;
         &:focus {
-            border: 1px solid $selected_borders_color;
+            border: 1px solid $selected_border;
         }
     }
 }

--- a/src/cinnamon/scss/sections/_overview.scss
+++ b/src/cinnamon/scss/sections/_overview.scss
@@ -7,7 +7,7 @@
 }
 .workspace-thumbnails-background {
     padding: 10px;
-    border: 1px solid $borders_color;
+    border: 1px solid $exterior_border;
     border-radius: $roundness;
     @extend %bg-grad-to-right;
 }
@@ -26,14 +26,13 @@
     border-left: 1px solid;
     border-bottom: 1px solid;
     border-color: $button_border;
-    transition-duration: 150;
     &:hover {
         background-image: url(assets/add-workspace-hover.png);
-        border-color: $selected_borders_color;
+        border-color: $selected_border;
     }
     &:active {
         background-image: url(assets/add-workspace.png);
-        border-color: $selected_borders_color;
+        border-color: $selected_border;
         background-color: $success_color;
     }
 }
@@ -48,11 +47,11 @@
     background-color: $dark_bg_color_trans;
 }
 .workspace-thumbnail-indicator {
-    border: 2px solid $borders_color;
+    border: 2px solid $exterior_border;
 }
 .window-caption {
     padding: 10px;
-    border: 1px solid $borders_color;
+    border: 1px solid $exterior_border;
     border-radius: $roundness;
     @extend %bg-grad-to-bottom;
     padding: 2px 8px;
@@ -76,7 +75,7 @@
     background-image: url(assets/trash-icon.png);
     background-size: 100px;
     background-color: $dark_bg_color_trans;
-    border: 1px solid $borders_color;
+    border: 1px solid $exterior_border;
     border-bottom-width: 0;
     border-radius: 20px 20px 0 0;
     height: 120px;
@@ -86,14 +85,14 @@
     @extend %bg-grad-to-bottom;
 }
 .expo-workspace-thumbnail-frame {
-    border: 1px solid $borders_color;
+    border: 1px solid $exterior_border;
     &#active {
-        border: 1px solid $selected_borders_color;
+        border: 1px solid $selected_border;
     }
 }
 .expo-workspaces-name-entry {
     padding: 10px;
-    border: 1px solid $borders_color;
+    border: 1px solid $exterior_border;
     border-radius: $roundness;
     @extend %bg-grad-to-bottom;
     selected-color: $selected_fg_color;
@@ -107,13 +106,13 @@
         @extend %selected-bg-grad-to-bottom;
         selected-color: $dark_fg_color;
         selection-background-color: $selected_bg_color;
-        border: 1px solid $selected_borders_color;
+        border: 1px solid $selected_border;
     }
     &:focus {
-        border: 1px solid $selected_borders_color;
+        border: 1px solid $selected_border;
     }
     &:hover {
-        border: 1px solid $selected_borders_color;
+        border: 1px solid $selected_border;
     }
 }
 // hot corners animation

--- a/src/cinnamon/scss/sections/_panel.scss
+++ b/src/cinnamon/scss/sections/_panel.scss
@@ -72,7 +72,7 @@
 .panel-top {
     @extend %bg-grad-to-bottom;
     border-bottom: 1px solid;
-    border-color: $borders_color;
+    border-color: $exterior_border;
     .window-list-item-box {
         @extend %bg-grad-to-top;
         &:active {
@@ -96,13 +96,13 @@
     }
     .panel-launchers .launcher:hover {
         border-bottom: 2px solid;
-        border-color: $selected_borders_color;
+        border-color: $selected_border;
     }
 }
 .panel-bottom {
     @extend %bg-grad-to-top;
     border-top: 1px solid;
-    border-color: $borders_color;
+    border-color: $exterior_border;
     .window-list-item-box {
         @extend %bg-grad-to-bottom;
         &:checked {
@@ -126,13 +126,13 @@
     }
     .panel-launchers .launcher:hover {
         border-top: 2px solid;
-        border-color: $selected_borders_color;
+        border-color: $selected_border;
     }
 }
 .panel-left {
     @extend %bg-grad-to-right;
     border-right: 1px solid;
-    border-color: $borders_color;
+    border-color: $exterior_border;
     .window-list-item-box {
         @extend %bg-grad-to-left;
         margin-right: 1px;
@@ -156,13 +156,13 @@
     }
     .panel-launchers .launcher:hover {
         border-right: 3px solid;
-        border-color: $selected_borders_color;
+        border-color: $selected_border;
     }
 }
 .panel-right {
     @extend %bg-grad-to-left;
     border-left: 1px solid;
-    border-color: $borders_color;
+    border-color: $exterior_border;
     .window-list-item-box {
         @extend %bg-grad-to-right;
         margin-left: 2px;
@@ -182,7 +182,7 @@
     }
     .panel-launchers .launcher:hover {
         border-left: 3px solid;
-        border-color: $selected_borders_color;
+        border-color: $selected_border;
     }
 }
 // a non feature - not worth themeing
@@ -251,7 +251,7 @@
     border-bottom: 2px solid;
 }
 .applet-spacer:highlight {
-    border: 1px solid $selected_borders_color;
+    border: 1px solid $selected_border;
 }
 .applet-box {
     color: $dark_fg_color;
@@ -270,7 +270,7 @@
         }
     }
     &:highlight {
-        border: 1px solid $selected_borders_color;
+        border: 1px solid $selected_border;
         color: $selected_bg_color;
         .applet-label {
             color: $selected_bg_color;
@@ -337,31 +337,31 @@
 }
 // progress was added with cinnamon 3.6 and allows compatible applications to use the window list as a progress bar
 .window-list-item-box {
-    border: 1px solid $borders_color;
+    border: 1px solid $interior_border;
     border-radius: $roundness;
     transition-duration: 150;
     &:hover {
-        border: 1px solid $selected_borders_color;
+        border: 1px solid $selected_border;
     }
     &:highlight {
-        border: 1px solid $selected_borders_color;
+        border: 1px solid $selected_border;
     }
     .progress {
         background-color: $success_color;
-        border: 1px solid $selected_borders_color;
+        border: 1px solid $selected_border;
         border-radius: $roundness;
-        color: info_fg_color;
+        color: $info_fg_color;
     }
 }
 .window-list-item-demands-attention {
     background-color: $info_bg_color;
-    color: info_fg_color;
+    color: $info_fg_color;
 }
 // cinnamon 3.8 will support an improved window-list-thumbnail preview which now has it's own selector
 .window-list-preview {
     @extend %bg-grad-to-right;
     border-radius: $roundness;
-    border: 1px solid $borders_color;
+    border: 1px solid $exterior_border;
     padding: 10px 15px;
     spacing: 1em;
     color: $dark_fg_color;
@@ -434,13 +434,13 @@
     width: 2em;
     height: 1em;
     color: $dark_fg_color;
-    border: 1px solid $borders_color;
+    border: 1px solid $interior_border;
     margin: 2px;
     transition-duration: 150;
     &:outlined {
         background-color: $selected_bg_color;
         color: $selected_fg_color;
-        border-color: $selected_borders_color;
+        border-color: $selected_border;
     }
 }
 // workspace switcher applet graph view
@@ -448,10 +448,10 @@
     padding: 2px;
     spacing: 2px;
     .workspace {
-        border: 1px solid $borders_color;
+        border: 1px solid $interior_border;
         @extend %bg-grad-to-bottom;
         &:active {
-            border: 1px solid $borders_color;
+            border: 1px solid $interior_border;
             @extend %selected-bg-grad-to-bottom;
             .windows {
                 -active-window-background: rgba(255, 255, 255, 0.8);


### PR DESCRIPTION
Hi,

This reworks the borders colors on Cinnamon surfaces so that interior borders (i.e. in the cinnamon menu panel) are semi transparent versions of $dark_fg_color and exterior borders (menu, panel edge, OSD borders are a mix of $dark_fg_color and $dark_bg_color. Overall effect is for more subtle interior borders in keeping with the GTK in application borders.

![screenshot from 2018-03-23 06-48-47](https://user-images.githubusercontent.com/29017677/37815413-a6278088-2e66-11e8-8295-7b96fe2b4103.png)
![screenshot from 2018-03-23 06-49-30](https://user-images.githubusercontent.com/29017677/37815414-a63e5c04-2e66-11e8-894e-e5debcbed6df.png)
![screenshot from 2018-03-23 06-49-54](https://user-images.githubusercontent.com/29017677/37815415-a653253a-2e66-11e8-8fa8-aa008185c65f.png)
![screenshot from 2018-03-23 06-50-29](https://user-images.githubusercontent.com/29017677/37815416-a668160c-2e66-11e8-8d4d-f60fae30de44.png)
