### PR TITLE
Cinnamon Theme - improved windows list hover effect

### DIFF
--- a/src/cinnamon/scss/_extends.scss
+++ b/src/cinnamon/scss/_extends.scss
@@ -7,8 +7,15 @@
     background-gradient-end: $light_bg_grad;
 }
 
+// hover to bottom
+%hover-bg-grad-to-bottom {
+    background-gradient-direction: vertical;
+    background-gradient-start: $dark_hover_bg_grad;
+    background-gradient-end: $light_hover_bg_grad;
+}
+
 // button to top
-%button-bg-grad-to-top{
+%button-bg-grad-to-top {
     background-gradient-direction: vertical;
     background-gradient-start: $light_button_bg_grad;
     background-gradient-end: $dark_button_bg_grad;
@@ -28,6 +35,13 @@
     background-gradient-end: $dark_bg_grad;
 }
 
+// hover to top
+%hover-bg-grad-to-top {
+    background-gradient-direction: vertical;
+    background-gradient-start: $light_hover_bg_grad;
+    background-gradient-end: $dark_hover_bg_grad;
+}
+
 // selected to bottom
 %selected-bg-grad-to-bottom {
     background-gradient-direction: vertical;
@@ -40,6 +54,20 @@
     background-gradient-direction: vertical;
     background-gradient-start: $light_selected_bg_grad;
     background-gradient-end: $dark_selected_bg_grad;
+}
+
+// hover selected to bottom
+%hover-selected-grad-to-bottom {
+    background-gradient-direction: vertical;
+    background-gradient-start: $dark_hover_selected_grad;
+    background-gradient-end: $light_hover_selected_grad;
+}
+
+// hover selected to top
+%hover-selected-grad-to-top {
+    background-gradient-direction: vertical;
+    background-gradient-start: $light_hover_selected_grad;
+    background-gradient-end: $dark_hover_selected_grad;
 }
 
 // to right
@@ -56,6 +84,20 @@
     background-gradient-end: $dark_bg_grad;
 }
 
+// hover to right
+%hover-bg-grad-to-right {
+    background-gradient-direction: horizontal;
+    background-gradient-start: $dark_hover_bg_grad;
+    background-gradient-end: $light_hover_bg_grad;
+}
+
+// hover to left
+%hover-bg-grad-to-left {
+    background-gradient-direction: horizontal;
+    background-gradient-start: $light_hover_bg_grad;
+    background-gradient-end: $dark_hover_bg_grad;
+}
+
 // selected to right
 %selected-bg-grad-to-right {
     background-gradient-direction: horizontal;
@@ -68,6 +110,20 @@
     background-gradient-direction: horizontal;
     background-gradient-start: $light_selected_bg_grad;
     background-gradient-end: $dark_selected_bg_grad;
+}
+
+// hover selected to right
+%hover-selected-grad-to-right {
+    background-gradient-direction: horizontal;
+    background-gradient-start: $dark_hover_selected_grad;
+    background-gradient-end: $light_hover_selected_grad;
+}
+
+// hover selected to left
+%hover-selected-grad-to-left {
+    background-gradient-direction: horizontal;
+    background-gradient-start: $light_hover_selected_grad;
+    background-gradient-end: $dark_hover_selected_grad;
 }
 
 // tooltip to top

--- a/src/cinnamon/scss/_global.scss
+++ b/src/cinnamon/scss/_global.scss
@@ -22,9 +22,19 @@ $darken_amount: 1 - (%GRADIENT% / 2);
 $light_bg_grad: if($lighten_amount > 1, lighten($dark_bg_color, ($lighten_amount - 1) * lightness($dark_bg_color)), $dark_bg_color);
 $dark_bg_grad: if($darken_amount < 1, darken($dark_bg_color, (1 - $darken_amount) * lightness($dark_bg_color)), $dark_bg_color);
 
-// selected background surface gradient start and end colors - used for buttons and window list
+// hovered background surface gradient start and end colors - used for window list
+$hover_bg_color: lighten($dark_bg_color, .05 * lightness($dark_bg_color));
+$light_hover_bg_grad: if($lighten_amount > 1, lighten($hover_bg_color, ($lighten_amount - 1) * lightness($hover_bg_color)), $hover_bg_color);
+$dark_hover_bg_grad: if($darken_amount < 1, darken($hover_bg_color, (1 - $darken_amount) * lightness($hover_bg_color)), $hover_bg_color);
+
+// selected background surface gradient start and end colors - used for window list & buttons
 $light_selected_bg_grad: if($lighten_amount > 1, lighten($selected_bg_color, ($lighten_amount - 1) * lightness($selected_bg_color)), $selected_bg_color);
 $dark_selected_bg_grad: if($darken_amount < 1, darken($selected_bg_color, (1 - $darken_amount) * lightness($selected_bg_color)), $selected_bg_color);
+
+// hovered selected background surface gradient start and end colors - used for window list
+$hover_selected_color: lighten($selected_bg_color, .05 * lightness($selected_bg_color));
+$light_hover_selected_grad: if($lighten_amount > 1, lighten($hover_selected_color, ($lighten_amount - 1) * lightness($hover_selected_color)), $hover_selected_color);
+$dark_hover_selected_grad: if($darken_amount < 1, darken($hover_selected_color, (1 - $darken_amount) * lightness($hover_selected_color)), $hover_selected_color);
 
 // button background surface gradient start and end colors - used for buttons
 $light_button_bg_grad: if($lighten_amount > 1, lighten($button_bg_color, ($lighten_amount - 1) * lightness($button_bg_color)), $button_bg_color);

--- a/src/cinnamon/scss/sections/_overview.scss
+++ b/src/cinnamon/scss/sections/_overview.scss
@@ -26,7 +26,6 @@
     border-left: 1px solid;
     border-bottom: 1px solid;
     border-color: $button_border;
-    transition-duration: 150;
     &:hover {
         background-image: url(assets/add-workspace-hover.png);
         border-color: $selected_borders_color;

--- a/src/cinnamon/scss/sections/_panel.scss
+++ b/src/cinnamon/scss/sections/_panel.scss
@@ -75,14 +75,26 @@
     border-color: $borders_color;
     .window-list-item-box {
         @extend %bg-grad-to-top;
+        &:hover {
+            @extend %hover-bg-grad-to-top;
+        }
         &:active {
             @extend %panel-top-shared;
+            &:hover {
+                @extend %hover-selected-grad-to-top;
+                }
         }
         &:checked {
             @extend %panel-top-shared;
+            &:hover {
+                @extend %hover-selected-grad-to-top;
+                }            
         }
         &:focus {
             @extend %panel-top-shared;
+            &:hover {
+                @extend %hover-selected-grad-to-top;
+                }
         }
     }
     .workspace-switcher {
@@ -105,11 +117,26 @@
     border-color: $borders_color;
     .window-list-item-box {
         @extend %bg-grad-to-bottom;
+        &:hover {
+            @extend %hover-bg-grad-to-bottom;
+        }
+        &:active {
+            @extend %panel-bottom-shared;
+            &:hover {
+                @extend %hover-selected-grad-to-bottom;
+                }            
+        }
         &:checked {
             @extend %panel-bottom-shared;
+            &:hover {
+                @extend %hover-selected-grad-to-bottom;
+                }           
         }
         &:focus {
             @extend %panel-bottom-shared;
+            &:hover {
+                @extend %hover-selected-grad-to-bottom;
+                }
         }
     }
     .workspace-switcher {
@@ -120,9 +147,6 @@
         margin-top: 2px;
     }
     .applet-label {
-    }
-    .windows-list-item-box:active {
-        @extend %panel-bottom-shared;
     }
     .panel-launchers .launcher:hover {
         border-top: 2px solid;
@@ -136,14 +160,26 @@
     .window-list-item-box {
         @extend %bg-grad-to-left;
         margin-right: 1px;
+        &:hover {
+            @extend %hover-bg-grad-to-left;
+        }
         &:active {
             @extend %panel-left-shared;
+            &:hover {
+                @extend %hover-selected-grad-to-left;
+                }
         }
         &:checked {
             @extend %panel-left-shared;
+            &:hover {
+                @extend %hover-selected-grad-to-left;
+                }
         }
         &:focus {
             @extend %panel-left-shared;
+            &:hover {
+                @extend %hover-selected-grad-to-left;
+                }
         }
     }
     .applet-box {
@@ -166,19 +202,31 @@
     .window-list-item-box {
         @extend %bg-grad-to-right;
         margin-left: 2px;
+        &:hover {
+            @extend %hover-bg-grad-to-right;
+        }
+        &:active {
+            @extend %panel-right-shared;
+            &:hover {
+                @extend %hover-selected-grad-to-right;
+                }
+        }
         &:checked {
             @extend %panel-right-shared;
+            &:hover {
+                @extend %hover-selected-grad-to-right;
+                }
         }
         &:focus {
             @extend %panel-right-shared;
+            &:hover {
+                @extend %hover-selected-grad-to-right;
+                }
         }
     }
     .applet-box {
         padding: 3px 1px;
         margin-left: 2px;
-    }
-    .windows-list-item-box:active {
-        @extend %panel-right-shared;
     }
     .panel-launchers .launcher:hover {
         border-left: 3px solid;
@@ -350,12 +398,12 @@
         background-color: $success_color;
         border: 1px solid $selected_borders_color;
         border-radius: $roundness;
-        color: info_fg_color;
+        color: $info_fg_color;
     }
 }
 .window-list-item-demands-attention {
     background-color: $info_bg_color;
-    color: info_fg_color;
+    color: $info_fg_color;
 }
 // cinnamon 3.8 will support an improved window-list-thumbnail preview which now has it's own selector
 .window-list-preview {


### PR DESCRIPTION
Hi,

This adds a subtle background color change to the hover effect for windows list items. It is more evident in lighter themes where the border highlighting is less apparent. The effect on darker themes is less apparent, but the border highlighting in darker themes is generally more visible.

The pointer isn't visible in this shot, but the far left item is hovered....

![screenshot from 2018-03-23 07-12-27](https://user-images.githubusercontent.com/29017677/37816111-a396d05a-2e69-11e8-9e1b-39da3d56da36.png)


